### PR TITLE
Workflow For Notifying ACCESS-NRI/build-ci that spack_packages is Updated

### DIFF
--- a/.github/workflows/dispatch-update-to-build-ci.yml
+++ b/.github/workflows/dispatch-update-to-build-ci.yml
@@ -6,12 +6,24 @@ on:
     tags:
       - "*.*.*"
 jobs:
+  extract-tag:
+    runs-on: ubuntu-latest
+    outputs:
+      tag: ${{ steps.tag-step.outputs.tag }}
+    steps:
+    - name: Clone repo
+      uses: actions/checkout@v3
+    - name: Extract tag
+      id: tag-step
+      run: echo "tag=${GITHUB_REF#refs/*/}" >> $GITHUB_OUTPUT
+      
   send-update-to-build-ci:
     name: Send Update to Build CI repo
     runs-on: ubuntu-latest
+    needs: extract-tag
     steps:
       - name: Send event to build-ci repo
         run: |
-          curl -XPOST -u "${{ secrets.RELEASE_BUILD_CI_PAT_USERNAME }}:${{ secrets.RELEASE_BUILD_CI_PAT }}" -H "Accept: application/vnd.github.everest-preview+json" -H "Content-Type: application/json" https://api.github.com/repos/ACCESS-NRI/build-ci/actions/workflows/build-and-push-image-base-spack.yml/dispatches --data '{"ref": "main"}'
+          curl -XPOST -u "${{ secrets.RELEASE_BUILD_CI_PAT_USERNAME }}:${{ secrets.RELEASE_BUILD_CI_PAT }}" -H "Accept: application/vnd.github.everest-preview+json" -H "Content-Type: application/json" https://api.github.com/repos/ACCESS-NRI/build-ci/actions/workflows/build-and-push-image-base-spack.yml/dispatches --data '{"ref": "main", "inputs":{"spack-packages-version": "${{ needs.extract-tag.outputs.tag }}"}}'
         
 

--- a/.github/workflows/dispatch-update-to-build-ci.yml
+++ b/.github/workflows/dispatch-update-to-build-ci.yml
@@ -12,6 +12,6 @@ jobs:
     steps:
       - name: Send event to build-ci repo
         run: |
-          curl -XPOST -u "${{ secrets.RELEASE_BUILD_CI_PAT_USERNAME }}:${{ secrets.RELEASE_BUILD_CI_PAT }}" -H "Accept: application/vnd.github.everest-preview+json" -H "Content-Type: application/json" https://api.github.com/repos/ACCESS-NRI/build-ci/actions/workflows/build-and-publish-base-spack.yml/dispatches --data '{"ref": "main"}'
+          curl -XPOST -u "${{ secrets.RELEASE_BUILD_CI_PAT_USERNAME }}:${{ secrets.RELEASE_BUILD_CI_PAT }}" -H "Accept: application/vnd.github.everest-preview+json" -H "Content-Type: application/json" https://api.github.com/repos/ACCESS-NRI/build-ci/actions/workflows/build-and-push-image-base-spack.yml/dispatches --data '{"ref": "main"}'
         
 

--- a/.github/workflows/dispatch-update-to-build-ci.yml
+++ b/.github/workflows/dispatch-update-to-build-ci.yml
@@ -5,6 +5,8 @@ on:
       - main
     tags: 
       - '*.*.*'
+    paths:
+      - 'packages/**'
 
 jobs:
   send-tag-update-to-build-ci:

--- a/.github/workflows/dispatch-update-to-build-ci.yml
+++ b/.github/workflows/dispatch-update-to-build-ci.yml
@@ -1,29 +1,18 @@
 name: "Dispatch Event to Build CI"
 on:
   push:
-    branches: 
+    branches:
       - main
-    tags:
-      - "*.*.*"
+    tags: 
+      - '*.*.*'
+
 jobs:
-  extract-tag:
-    runs-on: ubuntu-latest
-    outputs:
-      tag: ${{ steps.tag-step.outputs.tag }}
-    steps:
-    - name: Clone repo
-      uses: actions/checkout@v3
-    - name: Extract tag
-      id: tag-step
-      run: echo "tag=${GITHUB_REF#refs/*/}" >> $GITHUB_OUTPUT
-      
   send-update-to-build-ci:
     name: Send Update to Build CI repo
     runs-on: ubuntu-latest
-    needs: extract-tag
     steps:
-      - name: Send event to build-ci repo
+      - name: Send event and tag to build-ci repo
         run: |
-          curl -XPOST -u "${{ secrets.RELEASE_BUILD_CI_PAT_USERNAME }}:${{ secrets.RELEASE_BUILD_CI_PAT }}" -H "Accept: application/vnd.github.everest-preview+json" -H "Content-Type: application/json" https://api.github.com/repos/ACCESS-NRI/build-ci/actions/workflows/build-and-push-image-base-spack.yml/dispatches --data '{"ref": "main", "inputs":{"spack-packages-version": "${{ needs.extract-tag.outputs.tag }}"}}'
+          curl -XPOST -u "${{ secrets.RELEASE_BUILD_CI_PAT_USERNAME }}:${{ secrets.RELEASE_BUILD_CI_PAT }}" -H "Accept: application/vnd.github.everest-preview+json" -H "Content-Type: application/json" https://api.github.com/repos/ACCESS-NRI/build-ci/actions/workflows/build-and-push-image-base-spack.yml/dispatches --data '{"ref": "main", "inputs":{"spack-packages-version": "${{ github.ref_name }}"}}'
         
 

--- a/.github/workflows/dispatch-update-to-build-ci.yml
+++ b/.github/workflows/dispatch-update-to-build-ci.yml
@@ -9,11 +9,29 @@ on:
       - '**.py'
 
 jobs:
-  send-update-to-build-ci:
-    name: Send Update to Build CI repo
+  send-tag-update-to-build-ci:
+    name: Send Tag Update to Build CI repo
     runs-on: ubuntu-latest
+    if: github.ref_type == 'tag'
     steps:
-      - name: Get names of directories modified in push
+      - uses: actions/checkout@v3
+      - name: Get names of all package directories
+        id: directories
+        run: echo "modified=$(ls packages)" >> $GITHUB_OUTPUT
+        
+      - name: Send event and tag to build-ci repo
+        run: |
+          curl -XPOST -u "${{ secrets.RELEASE_BUILD_CI_PAT_USERNAME }}:${{ secrets.RELEASE_BUILD_CI_PAT }}" \
+            -H "Accept: application/vnd.github.everest-preview+json" \
+            -H "Content-Type: application/json" https://api.github.com/repos/ACCESS-NRI/build-ci/actions/workflows/notified-of-spack-packages-update.yml/dispatches \
+            --data '{"ref": "main", "inputs":{"spack-packages-version": "${{ github.ref_name }}", "packages": "${{ steps.directories.outputs.modified }}"}}'
+
+  send-branch-update-to-build-ci:
+    name: Send Branch Update to Build CI repo
+    runs-on: ubuntu-latest
+    if: github.ref_type == 'branch'
+    steps:
+      - name: Get names of directories modified in push/tag
         id: directories
         run: |
           # get all the changed files in the push, only keep the parent directory (corresponds to the package name), and turn it into a space-separated list!

--- a/.github/workflows/dispatch-update-to-build-ci.yml
+++ b/.github/workflows/dispatch-update-to-build-ci.yml
@@ -15,10 +15,13 @@ jobs:
     if: github.ref_type == 'tag'
     steps:
       - uses: actions/checkout@v3
+      
       - name: Get names of all package directories
         id: directories
-        run: echo "modified=$(ls packages)" >> $GITHUB_OUTPUT
-        
+        run: |
+          # list all the packages, turn it into a space-separated list!
+          echo "modified=$(ls packages | tr '\n' ' ')" >> $GITHUB_OUTPUT
+
       - name: Send event and tag to build-ci repo
         run: |
           curl -XPOST -u "${{ secrets.RELEASE_BUILD_CI_PAT_USERNAME }}:${{ secrets.RELEASE_BUILD_CI_PAT }}" \

--- a/.github/workflows/dispatch-update-to-build-ci.yml
+++ b/.github/workflows/dispatch-update-to-build-ci.yml
@@ -5,8 +5,6 @@ on:
       - main
     tags: 
       - '*.*.*'
-    paths:
-      - '**.py'
 
 jobs:
   send-tag-update-to-build-ci:

--- a/.github/workflows/dispatch-update-to-build-ci.yml
+++ b/.github/workflows/dispatch-update-to-build-ci.yml
@@ -1,7 +1,10 @@
 name: "Dispatch Event to Build CI"
 on:
   push:
-    branches: [main]
+    branches: 
+      - main
+    tags:
+      - "*.*.*"
 jobs:
   send-update-to-build-ci:
     name: Send Update to Build CI repo
@@ -9,6 +12,6 @@ jobs:
     steps:
       - name: Send event to build-ci repo
         run: |
-          curl -XPOST -u "${{ secrets.PAT_USERNAME}}:${{secrets.PAT_TOKEN}}" -H "Accept: application/vnd.github.everest-preview+json" -H "Content-Type: application/json" https://api.github.com/repos/ACCESS-NRI/build-ci/actions/workflows/build-and-publish-base-spack.yml/dispatches --data '{"ref": "main"}'
+          curl -XPOST -u "${{ secrets.RELEASE_BUILD_CI_PAT_USERNAME }}:${{ secrets.RELEASE_BUILD_CI_PAT }}" -H "Accept: application/vnd.github.everest-preview+json" -H "Content-Type: application/json" https://api.github.com/repos/ACCESS-NRI/build-ci/actions/workflows/build-and-publish-base-spack.yml/dispatches --data '{"ref": "main"}'
         
 

--- a/.github/workflows/dispatch-update-to-build-ci.yml
+++ b/.github/workflows/dispatch-update-to-build-ci.yml
@@ -13,6 +13,4 @@ jobs:
     steps:
       - name: Send event and tag to build-ci repo
         run: |
-          curl -XPOST -u "${{ secrets.RELEASE_BUILD_CI_PAT_USERNAME }}:${{ secrets.RELEASE_BUILD_CI_PAT }}" -H "Accept: application/vnd.github.everest-preview+json" -H "Content-Type: application/json" https://api.github.com/repos/ACCESS-NRI/build-ci/actions/workflows/build-and-push-image-base-spack.yml/dispatches --data '{"ref": "main", "inputs":{"spack-packages-version": "${{ github.ref_name }}"}}'
-        
-
+          curl -XPOST -u "${{ secrets.RELEASE_BUILD_CI_PAT_USERNAME }}:${{ secrets.RELEASE_BUILD_CI_PAT }}" -H "Accept: application/vnd.github.everest-preview+json" -H "Content-Type: application/json" https://api.github.com/repos/ACCESS-NRI/build-ci/actions/workflows/notified-of-spack-packages-update.yml/dispatches --data '{"ref": "main", "inputs":{"spack-packages-version": "${{ github.ref_name }}"}}'

--- a/.github/workflows/dispatch-update-to-build-ci.yml
+++ b/.github/workflows/dispatch-update-to-build-ci.yml
@@ -1,0 +1,14 @@
+name: "Dispatch Event to Build CI"
+on:
+  push:
+    branches: [main]
+jobs:
+  send-update-to-build-ci:
+    name: Send Update to Build CI repo
+    runs-on: ubuntu-latest
+    steps:
+      - name: Send event to build-ci repo
+        run: |
+          curl -XPOST -u "${{ secrets.PAT_USERNAME}}:${{secrets.PAT_TOKEN}}" -H "Accept: application/vnd.github.everest-preview+json" -H "Content-Type: application/json" https://api.github.com/repos/ACCESS-NRI/build-ci/actions/workflows/build-and-publish-base-spack.yml/dispatches --data '{"ref": "main"}'
+        
+

--- a/.github/workflows/dispatch-update-to-build-ci.yml
+++ b/.github/workflows/dispatch-update-to-build-ci.yml
@@ -5,12 +5,23 @@ on:
       - main
     tags: 
       - '*.*.*'
+    paths:
+      - '**.py'
 
 jobs:
   send-update-to-build-ci:
     name: Send Update to Build CI repo
     runs-on: ubuntu-latest
     steps:
+      - name: Get names of directories modified in push
+        id: directories
+        run: |
+          # get all the changed files in the push, only keep the parent directory (corresponds to the package name), and turn it into a space-separated list!
+          echo "modified=$(git diff --name-only ${{ github.event.after }} ${{ github.event.before }} | cut -d '/' -f 2 | tr '\n' ' ')" >> $GITHUB_OUTPUT
+          
       - name: Send event and tag to build-ci repo
         run: |
-          curl -XPOST -u "${{ secrets.RELEASE_BUILD_CI_PAT_USERNAME }}:${{ secrets.RELEASE_BUILD_CI_PAT }}" -H "Accept: application/vnd.github.everest-preview+json" -H "Content-Type: application/json" https://api.github.com/repos/ACCESS-NRI/build-ci/actions/workflows/notified-of-spack-packages-update.yml/dispatches --data '{"ref": "main", "inputs":{"spack-packages-version": "${{ github.ref_name }}"}}'
+          curl -XPOST -u "${{ secrets.RELEASE_BUILD_CI_PAT_USERNAME }}:${{ secrets.RELEASE_BUILD_CI_PAT }}" \
+            -H "Accept: application/vnd.github.everest-preview+json" \
+            -H "Content-Type: application/json" https://api.github.com/repos/ACCESS-NRI/build-ci/actions/workflows/notified-of-spack-packages-update.yml/dispatches \
+            --data '{"ref": "main", "inputs":{"spack-packages-version": "${{ github.ref_name }}", "packages": "${{ steps.directories.outputs.modified }}"}}'


### PR DESCRIPTION
GitHub Actions can be strange. In order for build-ci to know that spack_packages has been updated, spack_packages needs to notify build-ci that there has been a change. In this PR, workflows are added to notify build-ci that spack_packages has had a push to master, or a tag released. 

Related PR from build-ci: https://github.com/ACCESS-NRI/build-ci/pull/19

Should go partway to closing ACCESS-NRI/build-ci#4 !