### PR TITLE
Add a deterministic variant

### DIFF
--- a/packages/access-om2/package.py
+++ b/packages/access-om2/package.py
@@ -16,8 +16,13 @@ class AccessOm2(BundlePackage):
 
     version("2023.01.001-1")
 
-    depends_on("libaccessom2")
-    depends_on("cice5")
-    depends_on("mom5")
+    variant("deterministic", default=False, description="Deterministic build.")
+
+    depends_on("libaccessom2+deterministic", when="+deterministic")
+    depends_on("libaccessom2~deterministic", when="~deterministic")
+    depends_on("cice5+deterministic", when="+deterministic")
+    depends_on("cice5~deterministic", when="~deterministic")
+    depends_on("mom5+deterministic", when="+deterministic")
+    depends_on("mom5~deterministic", when="~deterministic")
 
     # There is no need for install() since there is no code.

--- a/packages/libaccessom2/package.py
+++ b/packages/libaccessom2/package.py
@@ -17,14 +17,25 @@ class Libaccessom2(CMakePackage):
 
     version("master", branch="master")
 
+    variant("deterministic", default=False, description="Deterministic build.")
+    variant('build_type',
+            default='Release',
+            description='The build type to build',
+            values=('Debug', 'Release')
+    )
+
     depends_on("cmake@3.20:", type="build")
     depends_on("pkgconf", type="build")
     # Depend on virtual package "mpi".
     depends_on("mpi")
-    depends_on("oasis3-mct")
+    depends_on("oasis3-mct+deterministic", when="+deterministic")
+    depends_on("oasis3-mct~deterministic", when="~deterministic")
     depends_on("datetime-fortran")
     depends_on("json-fortran")
     depends_on("netcdf-fortran@4.5.2:")
 
     def url_for_version(self, version):
         return "https://github.com/ACCESS-NRI/libaccessom2/tarball/{0}".format(version)
+
+    def cmake_args(self):
+        return [self.define_from_variant('DETERMINISTIC', "deterministic")]


### PR DESCRIPTION
* This PR is only focused on adding the deterministic variant.
* The general compiler flag audit will happen in https://github.com/ACCESS-NRI/ACCESS-OM/issues/12
* We'll likely end-up storing the compiler flags in an appropriate data structure and then extract the relevant compiler flags based on the variant/compiler.