### PR TITLE
Updated input parameters to fit with `build-ci` inputs

### DIFF
--- a/.github/workflows/dispatch-update-to-build-ci.yml
+++ b/.github/workflows/dispatch-update-to-build-ci.yml
@@ -16,4 +16,4 @@ jobs:
           curl -XPOST -u "${{ secrets.RELEASE_BUILD_CI_PAT_USERNAME }}:${{ secrets.RELEASE_BUILD_CI_PAT }}" \
             -H "Accept: application/vnd.github.everest-preview+json" \
             -H "Content-Type: application/json" https://api.github.com/repos/ACCESS-NRI/build-ci/actions/workflows/build-and-push-image-build.yml/dispatches \
-            --data '{"ref": "main", "inputs":{"spack-packages-build-required": "true", "spack-packages-version": "${{ github.ref_name }}", "model": "all"}}'
+            --data '{"ref": "main", "inputs":{"spack-packages-version": "${{ github.ref_name }}", "model": "all"}}'


### PR DESCRIPTION
The changes to `build-ci` removed the `spack-packages-build-required` input parameter, but this wasn't removed from spack_packages. This PR removes it. 