### PR TITLE
Add the ISSM model and supporting packages

### DIFF
--- a/packages/issm/package.py
+++ b/packages/issm/package.py
@@ -1,0 +1,53 @@
+# Copyright 2013-2023 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# Copyright 2023 Angus Gibson
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack.package import *
+
+
+class Issm(AutotoolsPackage):
+    """Ice-sheet and Sea-Level System Model"""
+
+    homepage = "https://issm.jpl.nasa.gov/"
+    svn = "https://issm.ess.uci.edu/svn/issm/issm/trunk"
+
+    version("develop")
+
+    depends_on("autoconf", type="build")
+    depends_on("automake", type="build")
+    depends_on("libtool", type="build")
+    depends_on("m4", type="build")
+
+    depends_on("mpi")
+    depends_on("petsc+metis+mumps+scalapack")
+    depends_on("m1qn3")
+
+    def autoreconf(self, spec, prefix):
+        autoreconf("--install", "--verbose", "--force")
+
+    def configure_args(self):
+        args = [
+          "--with-wrappers=no",
+          "--enable-debugging",
+          "--enable-development",
+          "--enable-shared",
+          "--without-kriging",
+        ]
+        args.append("--with-petsc-dir={0}".format(self.spec["petsc"].prefix))
+        args.append("--with-metis-dir={0}".format(self.spec["metis"].prefix))
+        args.append("--with-mumps-dir={0}".format(self.spec["mumps"].prefix))
+        args.append("--with-m1qn3-dir={0}".format(self.spec["m1qn3"].prefix.lib))
+
+        # Even though we set the MPI compilers manually, the build system
+        # wants us to explicitly request an MPI-enabled build by telling
+        # it the MPI include directory.
+        args.append("--with-mpi-include={0}".format(self.spec["mpi"].prefix.include))
+        args.append("CC=" + self.spec["mpi"].mpicc)
+        args.append("CXX=" + self.spec["mpi"].mpicxx)
+        args.append("FC=" + self.spec["mpi"].mpifc)
+        args.append("F77=" + self.spec["mpi"].mpif77)
+
+        return args

--- a/packages/m1qn3/m1qn3.patch
+++ b/packages/m1qn3/m1qn3.patch
@@ -1,3 +1,5 @@
+# Reproduced from externalpackages/m1qn3/patch/m1qn3.f.patch
+# in ISSM Subversion trunk.
 --- src/src/m1qn3.f     2009-10-20 06:39:35.000000000 -0400
 +++ m1qn3.f     2021-08-13 14:44:30.276019165 -0400
 @@ -802,7 +802,7 @@

--- a/packages/m1qn3/m1qn3.patch
+++ b/packages/m1qn3/m1qn3.patch
@@ -1,0 +1,11 @@
+--- src/src/m1qn3.f     2009-10-20 06:39:35.000000000 -0400
++++ m1qn3.f     2021-08-13 14:44:30.276019165 -0400
+@@ -802,7 +802,7 @@
+      &        "  iter  simul  stepsize            f                |g|",
+      &        "       |g|/|g0|"
+           write(io,
+-     &        '(1x,i5,2x,i5,2x,1pd8.2,2x,d21.14,2x,d11.5,2x,d10.4)')
++     &        '(1x,i5,2x,i5,2x,1pd9.2,2x,d21.14,2x,d12.5,2x,d11.4)')
+      &        niter, isim, t, f, gnorm, eps1
+       endif
+       if (impres.ge.5) write (io,940) eps1

--- a/packages/m1qn3/package.py
+++ b/packages/m1qn3/package.py
@@ -1,6 +1,8 @@
 # Copyright 2013-2023 Lawrence Livermore National Security, LLC and other
 # Spack Project Developers. See the top-level COPYRIGHT file for details.
 #
+# Copyright 2023 Angus Gibson
+#
 # SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 

--- a/packages/m1qn3/package.py
+++ b/packages/m1qn3/package.py
@@ -1,0 +1,43 @@
+# Copyright 2013-2023 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+
+from spack.package import *
+
+
+class M1qn3(MakefilePackage):
+    """Minimise functions depending on a very large number of variables."""
+
+    homepage = "https://who.rocq.inria.fr/Jean-Charles.Gilbert/modulopt/optimization-routines/m1qn3/m1qn3.html"
+    url = "https://issm.ess.uci.edu/files/externalpackages/m1qn3-3.3-distrib.tgz"
+
+    version("3.3", sha256="27c6a8f56a4080420c25ffb0743e3dece7c57cc1740776936f220b4ed28b89d9")
+
+    patch("m1qn3.patch")
+
+    def url_for_version(self, version):
+        url = "https://issm.ess.uci.edu/files/externalpackages/m1qn3-{0}-distrib.tgz"
+        return url.format(version)
+
+    def edit(self, spec, prefix):
+        with open("Makefile", "w") as f:
+            f.write(f"""
+LIB_EXT=a
+FC={spack_fc}
+install: libm1qn3.$(LIB_EXT) libddot.$(LIB_EXT)
+	install -D libm1qn3.$(LIB_EXT) {prefix}/lib/libm1qn3.$(LIB_EXT)
+	install -D libddot.$(LIB_EXT) {prefix}/lib/libddot.$(LIB_EXT)
+OBJECTS=src/m1qn3.o
+libm1qn3.$(LIB_EXT): $(OBJECTS)
+	ar -r $@ $(OBJECTS)
+	ranlib $@
+DDOT_OBJECTS=blas/ddot.o
+libddot.$(LIB_EXT): $(DDOT_OBJECTS)
+	ar -r $@ $(DDOT_OBJECTS)
+	ranlib $@
+%.o: %.f
+	$(FC) $(FFLAGS) -fPIC -c $< -o $@
+""")
+

--- a/packages/nci-intel-oneapi-mkl/package.py
+++ b/packages/nci-intel-oneapi-mkl/package.py
@@ -1,0 +1,15 @@
+# Copyright 2013-2023 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# Copyright 2023 Angus Gibson
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack.pkg.builtin.intel_oneapi_mkl import IntelOneapiMkl
+
+class NciIntelOneapiMkl(IntelOneapiMkl):
+    @property
+    def component_prefix(self):
+        # we don't need to join the version into the prefix
+        # on Gadi, because the paths have been rearranged
+        return self.prefix.join(self.component_dir)


### PR DESCRIPTION
As mentioned in #20, here is the ISSM package which pulls in PETSc and builds using Intel compilers and MKL on Gadi. The `packages.yaml` may need to be modified for site configurations to specify that `intel-oneapi-mkl` uses the `+cluster` variant in order to include ScaLAPACK and BLACS.

It's also possible that `intel-oneapi-mkl` can be renamed to something more NCI-specific, like the existing `nci-openmpi` package.