### PR TITLE
Removed unneeded '--format' argument

### DIFF
--- a/.github/workflows/py-checks.yml
+++ b/.github/workflows/py-checks.yml
@@ -26,4 +26,4 @@ jobs:
       - uses: chartboost/ruff-action@v1
         with:
           src: "${{ steps.get-files.outputs.all_changed_files }}"
-          args: "check --format github --preview --config .ruff.toml"
+          args: "check --preview --config .ruff.toml"

--- a/.ruff.toml
+++ b/.ruff.toml
@@ -1,5 +1,6 @@
 select = ["E","F"]
 ignore = ["E221","E241","E272","E731","F405","F821"]
 line-length = 80
+output-format = "github"
 
 # "E129", "F999" aren't supported


### PR DESCRIPTION
The '--format' argument is tripping up the pipeline, even though it is a valid argument in `ruff help check`. 
It isn't required for the workflow to run (mostly just pretty-printing), so it has been removed. Adding it to the `.ruff.toml` seems valid. 
