### PR TITLE
access-om2: Added link to git repo, removed hardcoded version string

### DIFF
--- a/packages/access-om2/package.py
+++ b/packages/access-om2/package.py
@@ -12,9 +12,9 @@ class AccessOm2(BundlePackage):
 
     homepage = "https://www.access-nri.org.au"
 
-    maintainers = ["harshula"]
+    git = "https://github.com/ACCESS-NRI/ACCESS-OM2.git"
 
-    version("2023.01.001-1")
+    maintainers = ["harshula"]
 
     variant("deterministic", default=False, description="Deterministic build.")
 

--- a/packages/access-om2/package.py
+++ b/packages/access-om2/package.py
@@ -16,6 +16,8 @@ class AccessOm2(BundlePackage):
 
     maintainers = ["harshula"]
 
+    version("latest")
+
     variant("deterministic", default=False, description="Deterministic build.")
 
     depends_on("libaccessom2+deterministic", when="+deterministic")


### PR DESCRIPTION
In this PR, we remove the hardcoded `version("2023.0.001-1")` and add in the git repo, so we can associate a particular build of access-om2 with a git commit (aka, so we can have a `spack install access-om2@git.2023.11.20` for example).  